### PR TITLE
Node access optimization

### DIFF
--- a/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
+++ b/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
@@ -59,6 +59,8 @@ SindarinBytecodeToASTCacheTest >> testLowerThanFirstBCOffsetAccessTest [
 
 { #category : #tests }
 SindarinBytecodeToASTCacheTest >> testNodeForBCOffsetRangeTest [
+	"As we associate each node to each possible bytecode offset that can refer to it,
+	we have to check that associations are consistent between a range and a node"
 	| pcRange |
 	pcRange := 47 to: 48.
 	pcRange do: [ :pc | 

--- a/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
+++ b/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #SindarinBytecodeToASTCacheTestd,
+	#name : #SindarinBytecodeToASTCacheTest,
 	#superclass : #TestCase,
 	#instVars : [
 		'cache',
@@ -9,7 +9,7 @@ Class {
 }
 
 { #category : #running }
-SindarinBytecodeToASTCacheTestd >> setUp [
+SindarinBytecodeToASTCacheTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	super setUp.	
 	compiledMethod := ScriptableDebuggerTests >> #helperMethod23.
@@ -17,23 +17,23 @@ SindarinBytecodeToASTCacheTestd >> setUp [
 ]
 
 { #category : #helpers }
-SindarinBytecodeToASTCacheTestd >> testCacheInInterval: interval equalsNode: aNode [
+SindarinBytecodeToASTCacheTest >> testCacheInInterval: interval equalsNode: aNode [
 	interval do: [ :i | 
 		self assert: (cache nodeForPC: i) identicalTo: aNode ]
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testCachedMethodNode [
+SindarinBytecodeToASTCacheTest >> testCachedMethodNode [
 	self assert: cache methodNode identicalTo: compiledMethod ast
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testFirstBCOffsetTest [
+SindarinBytecodeToASTCacheTest >> testFirstBCOffsetTest [
 	self assert: cache firstBcOffset equals: compiledMethod initialPC
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testHigherThanLastBCOffsetAccessTest [
+SindarinBytecodeToASTCacheTest >> testHigherThanLastBCOffsetAccessTest [
 	| pc |
 	pc := cache lastBcOffset + 5.
 	self
@@ -42,7 +42,7 @@ SindarinBytecodeToASTCacheTestd >> testHigherThanLastBCOffsetAccessTest [
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testLastBCOffsetTest [
+SindarinBytecodeToASTCacheTest >> testLastBCOffsetTest [
 	self
 		assert: cache lastBcOffset
 		equals:
@@ -51,14 +51,14 @@ SindarinBytecodeToASTCacheTestd >> testLastBCOffsetTest [
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testLowerThanFirstBCOffsetAccessTest [
+SindarinBytecodeToASTCacheTest >> testLowerThanFirstBCOffsetAccessTest [
 	self
 		testCacheInInterval: (0 to: cache firstBcOffset - 1)
 		equalsNode: compiledMethod ast
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testNodeForBCOffsetRangeTest [
+SindarinBytecodeToASTCacheTest >> testNodeForBCOffsetRangeTest [
 	| pcRange |
 	pcRange := 47 to: 48.
 	pcRange do: [ :pc | 
@@ -68,7 +68,7 @@ SindarinBytecodeToASTCacheTestd >> testNodeForBCOffsetRangeTest [
 ]
 
 { #category : #tests }
-SindarinBytecodeToASTCacheTestd >> testNodeForBCOffsetTest [
+SindarinBytecodeToASTCacheTest >> testNodeForBCOffsetTest [
 	| pc |
 	pc := 51.
 	self

--- a/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
+++ b/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
@@ -12,7 +12,7 @@ Class {
 SindarinBytecodeToASTCacheTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	super setUp.	
-	compiledMethod := ScriptableDebuggerTests >> #helperMethod23.
+	compiledMethod := ScriptableDebuggerTests >> #helperMethod12.
 	cache := SindarinBytecodeToASTCache generateForCompiledMethod: compiledMethod
 ]
 
@@ -61,12 +61,13 @@ SindarinBytecodeToASTCacheTest >> testLowerThanFirstBCOffsetAccessTest [
 SindarinBytecodeToASTCacheTest >> testNodeForBCOffsetRangeTest [
 	"As we associate each node to each possible bytecode offset that can refer to it,
 	we have to check that associations are consistent between a range and a node"
+
 	| pcRange |
-	pcRange := 47 to: 48.
+	pcRange := 0 to: cache lastBcOffset.
 	pcRange do: [ :pc | 
 		self
-			testCacheInInterval: pcRange
-			equalsNode: (compiledMethod sourceNodeForPC: pc) ]
+			assert: (cache nodeForPC: pc)
+			identicalTo: (compiledMethod sourceNodeForPC: pc) ]
 ]
 
 { #category : #tests }

--- a/Sindarin-Tests/SindarinBytecodeToASTCacheTestd.class.st
+++ b/Sindarin-Tests/SindarinBytecodeToASTCacheTestd.class.st
@@ -1,0 +1,77 @@
+Class {
+	#name : #SindarinBytecodeToASTCacheTestd,
+	#superclass : #TestCase,
+	#instVars : [
+		'cache',
+		'compiledMethod'
+	],
+	#category : #'Sindarin-Tests'
+}
+
+{ #category : #running }
+SindarinBytecodeToASTCacheTestd >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	super setUp.	
+	compiledMethod := ScriptableDebuggerTests >> #helperMethod23.
+	cache := SindarinBytecodeToASTCache generateForCompiledMethod: compiledMethod
+]
+
+{ #category : #helpers }
+SindarinBytecodeToASTCacheTestd >> testCacheInInterval: interval equalsNode: aNode [
+	interval do: [ :i | 
+		self assert: (cache nodeForPC: i) identicalTo: aNode ]
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testCachedMethodNode [
+	self assert: cache methodNode identicalTo: compiledMethod ast
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testFirstBCOffsetTest [
+	self assert: cache firstBcOffset equals: compiledMethod initialPC
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testHigherThanLastBCOffsetAccessTest [
+	| pc |
+	pc := cache lastBcOffset + 5.
+	self
+		assert: (cache nodeForPC: pc)
+		identicalTo: (compiledMethod sourceNodeForPC: pc)
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testLastBCOffsetTest [
+	self
+		assert: cache lastBcOffset
+		equals:
+			compiledMethod ast ir startSequence withAllSuccessors last last
+				bytecodeOffset
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testLowerThanFirstBCOffsetAccessTest [
+	self
+		testCacheInInterval: (0 to: cache firstBcOffset - 1)
+		equalsNode: compiledMethod ast
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testNodeForBCOffsetRangeTest [
+	| pcRange |
+	pcRange := 47 to: 48.
+	pcRange do: [ :pc | 
+		self
+			testCacheInInterval: pcRange
+			equalsNode: (compiledMethod sourceNodeForPC: pc) ]
+]
+
+{ #category : #tests }
+SindarinBytecodeToASTCacheTestd >> testNodeForBCOffsetTest [
+	| pc |
+	pc := 51.
+	self
+		assert: (cache nodeForPC: pc)
+		identicalTo: (compiledMethod sourceNodeForPC: pc)
+]

--- a/Sindarin/SindarinBytecodeToASTCache.class.st
+++ b/Sindarin/SindarinBytecodeToASTCache.class.st
@@ -33,6 +33,19 @@ SindarinBytecodeToASTCache >> bcToASTMap [
 	^ bcToASTMap
 ]
 
+{ #category : #private }
+SindarinBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
+	| sortedBCOffsets |
+	sortedBCOffsets := bcToASTMap keys asSortedCollection.
+	1 to: sortedBCOffsets size - 1 do: [ :index | 
+		| bcAtIndex bcAtNextIndex |
+		bcAtIndex := sortedBCOffsets at: index.
+		bcAtNextIndex := sortedBCOffsets at: index + 1.
+		bcAtIndex < bcAtNextIndex ifTrue: [ 
+			bcAtIndex to: bcAtNextIndex - 1 do: [ :i | 
+			bcToASTMap at: i put: (bcToASTMap at: bcAtIndex) ] ] ]
+]
+
 { #category : #accessing }
 SindarinBytecodeToASTCache >> firstBcOffset [
 	^ firstBcOffset
@@ -44,16 +57,15 @@ SindarinBytecodeToASTCache >> generateForCompiledMethod: compiledMethod [
 	methodNode := compiledMethod ast.
 	methodIR := methodNode ir.
 	bcToASTMap := Dictionary new.
-	firstBcOffset := methodIR startSequence withAllSuccessors first first
-		                 bytecodeOffset.
+	firstBcOffset := compiledMethod initialPC.
 	currentBcOffset := firstBcOffset.
 	methodIR startSequence withAllSuccessors do: [ :seq | 
 		seq do: [ :ir | 
 			ir ifNotNil: [ 
-				currentBcOffset to: ir bytecodeOffset do: [ :i | 
-				bcToASTMap at: i put: ir sourceNode ].
+				bcToASTMap at: ir bytecodeOffset ifAbsentPut: [ ir sourceNode ].
 				currentBcOffset := ir bytecodeOffset + 1 ] ] ].
-	lastBcOffset := currentBcOffset - 1
+	lastBcOffset := currentBcOffset - 1.
+	self fillMissingBCOffsetsWithLastBCOffsetNodes
 ]
 
 { #category : #accessing }

--- a/Sindarin/SindarinBytecodeToASTCache.class.st
+++ b/Sindarin/SindarinBytecodeToASTCache.class.st
@@ -35,6 +35,11 @@ SindarinBytecodeToASTCache >> bcToASTMap [
 
 { #category : #private }
 SindarinBytecodeToASTCache >> fillMissingBCOffsetsWithLastBCOffsetNodes [
+	"It happens that different bytecode offsets map to the same AST node.
+	These cases are detected when there is no node mapped between, for example, bcOffset 46 and bcOffset 50.
+	In that case, we take every possible bytecode index between 46 and 50 (i.e., 47, 48, 49),
+	and we map them to the same node as the last mapped bytecode offset, here 46."
+
 	| sortedBCOffsets |
 	sortedBCOffsets := bcToASTMap keys asSortedCollection.
 	1 to: sortedBCOffsets size - 1 do: [ :index | 

--- a/Sindarin/SindarinBytecodeToASTCache.class.st
+++ b/Sindarin/SindarinBytecodeToASTCache.class.st
@@ -1,0 +1,74 @@
+"
+I cache a mapping between possible bytecode offsets and the AST nodes they correspond to for a given compiled method.
+
+Instanciate me using my class method generateForCompiledMethod: and give me as parameter a compiled method.
+
+Use me through the node access API method nodeForPC: and give me a program counter as parameter.
+
+I store: 
+- firstBcOffset: The first bytecode pc. If you try to access a pc below that first pc, I return the method node.
+- lastBcOffset: The last bytecode pc. If you try to access a pc after this last pc, I return the node associated with the last pc.
+- bcToASTMap: A map associating each possible pc between firstBcOffset and lastBcOffset and the corresponding ast node.
+- the methode node.
+"
+Class {
+	#name : #SindarinBytecodeToASTCache,
+	#superclass : #Object,
+	#instVars : [
+		'firstBcOffset',
+		'lastBcOffset',
+		'bcToASTMap',
+		'methodNode'
+	],
+	#category : #Sindarin
+}
+
+{ #category : #initialization }
+SindarinBytecodeToASTCache class >> generateForCompiledMethod: compiledMethod [
+	^self new generateForCompiledMethod: compiledMethod
+]
+
+{ #category : #accessing }
+SindarinBytecodeToASTCache >> bcToASTMap [
+	^ bcToASTMap
+]
+
+{ #category : #accessing }
+SindarinBytecodeToASTCache >> firstBcOffset [
+	^ firstBcOffset
+]
+
+{ #category : #initialization }
+SindarinBytecodeToASTCache >> generateForCompiledMethod: compiledMethod [
+	| methodIR currentBcOffset |
+	methodNode := compiledMethod ast.
+	methodIR := methodNode ir.
+	bcToASTMap := Dictionary new.
+	firstBcOffset := methodIR startSequence withAllSuccessors first first
+		                 bytecodeOffset.
+	currentBcOffset := firstBcOffset.
+	methodIR startSequence withAllSuccessors do: [ :seq | 
+		seq do: [ :ir | 
+			ir ifNotNil: [ 
+				currentBcOffset to: ir bytecodeOffset do: [ :i | 
+				bcToASTMap at: i put: ir sourceNode ].
+				currentBcOffset := ir bytecodeOffset + 1 ] ] ].
+	lastBcOffset := currentBcOffset - 1
+]
+
+{ #category : #accessing }
+SindarinBytecodeToASTCache >> lastBcOffset [
+	^ lastBcOffset
+]
+
+{ #category : #accessing }
+SindarinBytecodeToASTCache >> methodNode [
+	^ methodNode
+]
+
+{ #category : #'node access' }
+SindarinBytecodeToASTCache >> nodeForPC: pc [
+	pc < firstBcOffset ifTrue: [ ^ methodNode ].
+	pc > lastBcOffset ifTrue: [ ^ bcToASTMap at: lastBcOffset ].
+	^ bcToASTMap at: pc
+]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -20,7 +20,9 @@ Class {
 	#instVars : [
 		'process',
 		'debugSession',
-		'stepHooks'
+		'stepHooks',
+		'nodeMapForMethod',
+		'debugStarted'
 	],
 	#category : #Sindarin
 }
@@ -96,7 +98,7 @@ SindarinDebugger >> contextIsAboutToSignalException: aContext [
 	"Returns whether aContext is about to execute a message-send of selector #signal to an instance of the Exception class (or one of its subclasses)"
 
 	| node |
-	node := aContext method sourceNodeForPC: aContext pc.
+	node := (self nodeMapForMethod: aContext method) nodeForPC: aContext pc.
 	node isMessage
 		ifFalse: [ ^ false ].
 	node selector = #signal
@@ -165,6 +167,7 @@ SindarinDebugger >> debug: aBlock [
 		debugSession deactivateEventTriggering.
 	[ self selector = #newProcess] whileFalse: [ self step]. "Step the process to get out of the on:do: context added at the bottom of its stack"
 	[self selector = #newProcess] whileTrue: [ self step ]. "Step the process so that it leaves BlockClosure>>#newProcess and enters the block for which a process was created"
+	debugStarted := true.
 	^ self
 ]
 
@@ -177,6 +180,7 @@ SindarinDebugger >> debugSession [
 { #category : #initialization }
 SindarinDebugger >> initialize [
 	stepHooks := OrderedCollection new.
+	debugStarted := false
 ]
 
 { #category : #stackAccess }
@@ -248,7 +252,29 @@ SindarinDebugger >> method [
 SindarinDebugger >> node [
 	"Returns the AST node about to be executed by the top context of the execution"
 
-	^ self context method sourceNodeForPC: self context pc
+	debugStarted ifFalse: [ 
+		"Until the debug session is started, node is returned using the unoptimized version"
+		"Sindarin starts by executing controlled steps to exit the caller code (e.g. tests)
+		before entering the actual debugged code, and we do not want to cache nodes for the 
+		caller code."
+		^ self context method sourceNodeForPC: self context pc ].
+	"Once the hand is given to the tool or user, we start caching nodes for better performance"
+	^ self nodeMap nodeForPC: self context pc
+]
+
+{ #category : #astAndAstMapping }
+SindarinDebugger >> nodeMap [
+	^self nodeMapForMethod: self context method 
+]
+
+{ #category : #astAndAstMapping }
+SindarinDebugger >> nodeMapForMethod: aCompiledMethod [
+	nodeMapForMethod ifNil: [ nodeMapForMethod := Dictionary new ].
+	^ (nodeMapForMethod
+		   at: aCompiledMethod methodClass name
+		   ifAbsentPut: [ Dictionary new ])
+		  at: aCompiledMethod selector
+		  ifAbsentPut: [ SindarinBytecodeToASTCache generateForCompiledMethod: aCompiledMethod ]
 ]
 
 { #category : #'graphical debugger' }


### PR DESCRIPTION
Experiments of node access while stepping in Sindarin.
Now it lazily builds a cache of all possible bytecode offsets to their associated AST nodes and accesses this cache instead of searching nodes in the IR each time.