### PR TITLE
Breaking sin debug session inheritance refactoring

### DIFF
--- a/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
+++ b/Sindarin-Tests/SindarinBytecodeToASTCacheTest.class.st
@@ -12,7 +12,7 @@ Class {
 SindarinBytecodeToASTCacheTest >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	super setUp.	
-	compiledMethod := ScriptableDebuggerTests >> #helperMethod12.
+	compiledMethod := SindarinDebuggerTests >> #helperMethod12.
 	cache := SindarinBytecodeToASTCache generateForCompiledMethod: compiledMethod
 ]
 

--- a/Sindarin-Tests/SindarinDebugSessionTest.class.st
+++ b/Sindarin-Tests/SindarinDebugSessionTest.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : #SindarinDebugSessionTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'debugSession',
+		'sindarinSession'
+	],
+	#category : #'Sindarin-Tests'
+}
+
+{ #category : #running }
+SindarinDebugSessionTest >> setUp [
+	"Hooks that subclasses may override to define the fixture of test."
+	debugSession := DebugSession new.
+	sindarinSession := debugSession asSindarinDebugSession.	
+]
+
+{ #category : #tests }
+SindarinDebugSessionTest >> testDebugSessionAsSindarinDebugSession [
+	self assert: sindarinSession debugSession identicalTo: debugSession
+]
+
+{ #category : #tests }
+SindarinDebugSessionTest >> testSindarinSessionAsSindarinDebugSession [
+	self assert: sindarinSession asSindarinDebugSession identicalTo: sindarinSession
+]
+
+{ #category : #tests }
+SindarinDebugSessionTest >> testSindarinSessionInstantiation [
+	|sessionName process|
+	sessionName := 'TestSDS'.
+	process := [] newProcess.
+	sindarinSession := SindarinDebugSession newWithName: sessionName forProcess: process.
+	self assert: sindarinSession debugSession notNil.
+	self assert: sindarinSession debugSession name equals: sessionName.
+	self assert: sindarinSession debugSession process identicalTo: process.
+]

--- a/Sindarin-Tests/SindarinDebuggerTests.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTests.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #ScriptableDebuggerTests,
+	#name : #SindarinDebuggerTests,
 	#superclass : #TestCase,
 	#instVars : [
 		'breakpointsBeforeTest',
@@ -9,21 +9,21 @@ Class {
 }
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod1 [
+SindarinDebuggerTests >> helperMethod1 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod10 [
+SindarinDebuggerTests >> helperMethod10 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod11 [
+SindarinDebuggerTests >> helperMethod11 [
 	| a |
 	a := 5.
 	self helperMethod12.
@@ -32,150 +32,150 @@ ScriptableDebuggerTests >> helperMethod11 [
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod12 [
+SindarinDebuggerTests >> helperMethod12 [
 	| i |
 	i := 5.
 	[ i=0 ] whileFalse: [ i := i - 1 ].
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod13 [
+SindarinDebuggerTests >> helperMethod13 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod14 [
+SindarinDebuggerTests >> helperMethod14 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod15 [
+SindarinDebuggerTests >> helperMethod15 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod16 [
+SindarinDebuggerTests >> helperMethod16 [
 	^ 1+1.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod17: storeContextBlock [
+SindarinDebuggerTests >> helperMethod17: storeContextBlock [
 	storeContextBlock value: thisContext.
 	Point x:5 y: 7.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod18: anArg with: anotherArg [
+SindarinDebuggerTests >> helperMethod18: anArg with: anotherArg [
 	Point x: 5 y: 7.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod19 [
+SindarinDebuggerTests >> helperMethod19 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod2 [
+SindarinDebuggerTests >> helperMethod2 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod20 [
+SindarinDebuggerTests >> helperMethod20 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod21 [
+SindarinDebuggerTests >> helperMethod21 [
 	self helperMethod22
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod22 [
+SindarinDebuggerTests >> helperMethod22 [
 	^ Point new
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod23 [
+SindarinDebuggerTests >> helperMethod23 [
 	testObjectPoint sign.
 	testObjectPoint extent: (Point x:3 y: 4).
 	Point new.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod24 [
+SindarinDebuggerTests >> helperMethod24 [
 	| p |
 	p := Point new.
 	p sign.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod3 [
+SindarinDebuggerTests >> helperMethod3 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod4 [
+SindarinDebuggerTests >> helperMethod4 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod5 [
+SindarinDebuggerTests >> helperMethod5 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod6 [
+SindarinDebuggerTests >> helperMethod6 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod7 [
+SindarinDebuggerTests >> helperMethod7 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod8 [
+SindarinDebuggerTests >> helperMethod8 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> helperMethod9 [
+SindarinDebuggerTests >> helperMethod9 [
 	| a |
 	a := 5.
 	^ Point x: 5 y: '3' asInteger.
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> runCaseManaged [
+SindarinDebuggerTests >> runCaseManaged [
 	^ self runCase
 ]
 
 { #category : #running }
-ScriptableDebuggerTests >> setUp [
+SindarinDebuggerTests >> setUp [
 	"Hooks that subclasses may override to define the fixture of test."
 	breakpointsBeforeTest := VirtualBreakpoint all.
 	VirtualBreakpoint all removeAll.
@@ -183,13 +183,13 @@ ScriptableDebuggerTests >> setUp [
 ]
 
 { #category : #running }
-ScriptableDebuggerTests >> tearDown [
+SindarinDebuggerTests >> tearDown [
 	VirtualBreakpoint all removeAll.
 	breakpointsBeforeTest do: [ :brkpt | VirtualBreakpoint all add: brkpt ].
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testAddStepHook [
+SindarinDebuggerTests >> testAddStepHook [
 	| stepCounter stepHook scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod11 ].
 	stepCounter := 0.
@@ -201,157 +201,173 @@ ScriptableDebuggerTests >> testAddStepHook [
 	self assert: stepCounter equals: 21.
 	scdbg removeStepHook: stepHook.
 	scdbg stepOver.
-	self assert: stepCounter equals: 21.
+	self assert: stepCounter equals: 21
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testArguments [
+SindarinDebuggerTests >> testArguments [
 	| p scdbg |
 	p := Point new.
 	scdbg := SindarinDebugger debug: [ self helperMethod18: 1 with: p ].
 	scdbg step.
 	self assert: scdbg arguments size equals: 2.
 	self assert: (scdbg arguments at: 1) equals: 1.
-	self assert: (scdbg arguments at: 2) equals: p.
+	self assert: (scdbg arguments at: 2) equals: p
 	
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testAssignmentValue [
+SindarinDebuggerTests >> testAssignmentValue [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod2 ].
 	scdbg step.
-	self assert: scdbg assignmentValue equals: 5.
+	self assert: scdbg assignmentValue equals: 5
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testAssignmentVariableName [
+SindarinDebuggerTests >> testAssignmentVariableName [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod3 ].
 	scdbg step.
-	self assert: scdbg assignmentVariableName equals: #a.
+	self assert: scdbg assignmentVariableName equals: #a
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testContext [
+SindarinDebuggerTests >> testContext [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod15 ].
 	self assert: scdbg context equals: scdbg debugSession interruptedContext.
 	scdbg step.
-	self assert: scdbg context equals: scdbg debugSession interruptedContext.
+	self assert: scdbg context equals: scdbg debugSession interruptedContext
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testContinue [
+SindarinDebuggerTests >> testContinue [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
-	scdbg step; step.
+	scdbg
+		step;
+		step.
 	self assert: scdbg node isMessage.
 	self assert: scdbg node selector equals: #asInteger.
 	scdbg setBreakpoint.
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg continue.
 	self assert: scdbg node isMessage.
-	self assert: scdbg node selector equals: #asInteger.
+	self assert: scdbg node selector equals: #asInteger
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testContinueUntilTheEnd [
+SindarinDebuggerTests >> testContinueUntilTheEnd [
 	"Test the #continue method when no breakpoint/halt is set. It should step the execution until the end and NOT freeze the image"
+
 	| scdbg semaphore |
+	self flag: 'What is "setup code for the timeout?'.
 	"VVV Setup code for the timeout"
 	semaphore := Semaphore new.
-	[
-	"^^^ Setup code for the timeout"
-	
+	[ "^^^ Setup code for the timeout"
 	scdbg := SindarinDebugger debug: [ self helperMethod20 ].
 	scdbg continue.
 	self assert: scdbg isExecutionFinished.
-	
+
 	"VVV Code for the timeout"
-	semaphore signal
-	] fork.
-	semaphore wait: 5 seconds onCompletion: [ 'success' ] onTimeout: [ self assert: false description: 'Test timed out' ].
-	"^^^ Setup code for the timeout"
+	semaphore signal ] fork.
+	semaphore
+		wait: 5 seconds
+		onCompletion: [ 'success' ]
+		onTimeout: [ "^^^ Setup code for the timeout" self assert: false description: 'Test timed out' ]
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testIsExecutionFinished [
+SindarinDebuggerTests >> testIsExecutionFinished [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod16 ].
-	self assert: scdbg isExecutionFinished not.
-	scdbg stepOver; step; step; stepOver; step; stepOver; step.
+	self deny: scdbg isExecutionFinished.
+	scdbg
+		stepOver;
+		step;
+		step;
+		stepOver;
+		step;
+		stepOver;
+		step.
 	"Reached `self isActiveProcess` in Process>>#terminate"
-	self assert: scdbg isExecutionFinished.
+	self assert: scdbg isExecutionFinished
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMessageArguments [
+SindarinDebuggerTests >> testMessageArguments [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod4 ].
 	scdbg step; step.
 	self assert: scdbg messageArguments isEmpty.
 	scdbg stepOver.
 	self assert: (scdbg messageArguments at: 1) equals: 5.
-	self assert: (scdbg messageArguments at: 2) equals: 3.
+	self assert: (scdbg messageArguments at: 2) equals: 3
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMessageReceiver [
+SindarinDebuggerTests >> testMessageReceiver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod5 ].
 	self assert: scdbg messageReceiver equals: self.
 	scdbg step; step.
-	self assert: scdbg messageReceiver equals: '3'.
+	self assert: scdbg messageReceiver equals: '3'
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMessageSelector [
+SindarinDebuggerTests >> testMessageSelector [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod6 ].
 	self assert: scdbg messageSelector equals: #helperMethod6.
 	scdbg step; step.
 	self assert: scdbg messageSelector equals: #asInteger.
 	scdbg stepOver.
-	self assert: scdbg messageSelector equals: #x:y:.
+	self assert: scdbg messageSelector equals: #x:y:
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMessageTo [
+SindarinDebuggerTests >> testMessageTo [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod23 ].
-	scdbg step. "Step to <testObjectPoint sign.> call"
+	scdbg step.	"Step to <testObjectPoint sign.> call"
 	self assert: (scdbg message: #sign to: testObjectPoint).
-	scdbg stepOver; stepOver. "Step to <testObjectPoint extent: ...> call"
+	scdbg
+		stepOver;
+		stepOver.	"Step to <testObjectPoint extent: ...> call"
 	self assert: (scdbg message: #extent: to: testObjectPoint).
-	self assert: (scdbg message: #bogus to: testObjectPoint) not. "Should return false with wrong selector but correct receiver"
-	self assert: (scdbg message: #extent: to: Point new) not. "Shoudl return false with correct selector but wrong receiver"
+	
+	"Should return false with wrong selector but correct receiver"
+	self deny: (scdbg message: #bogus to: testObjectPoint).
+	
+	"Should return false with correct selector but wrong receiver"
+	self deny: (scdbg message: #extent: to: Point new)	
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMessageToInstanceOf [
+SindarinDebuggerTests >> testMessageToInstanceOf [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod24 ].
 	scdbg step; stepOver: 2. "Step to <p sign> call"
 	self assert: (scdbg message: #sign toInstanceOf: Point).
 	self assert: (scdbg message: #sign toInstanceOf: Object).
-	self assert: (scdbg message: #sign toInstanceOf: Rectangle) not.
-	self assert: (scdbg message: #bogus toInstanceOf: Point) not.
+	self deny: (scdbg message: #sign toInstanceOf: Rectangle).
+	self deny: (scdbg message: #bogus toInstanceOf: Point)
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testMethod [
+SindarinDebuggerTests >> testMethod [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod7 ].
-	self assert: scdbg method equals: ScriptableDebuggerTests>>#testMethod.
+	self assert: scdbg method equals: SindarinDebuggerTests>>#testMethod.
 	scdbg step.
-	self assert: scdbg method equals: ScriptableDebuggerTests>>#helperMethod7.
+	self assert: scdbg method equals: SindarinDebuggerTests>>#helperMethod7.
 	scdbg step; step.
-	self assert: scdbg method equals: String>>#asInteger.
+	self assert: scdbg method equals: String>>#asInteger
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testNode [
+SindarinDebuggerTests >> testNode [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod1 ].
 	node := scdbg node.
@@ -364,11 +380,11 @@ ScriptableDebuggerTests >> testNode [
 	scdbg step.
 	node := scdbg node.
 	self assert: node isMessage.
-	self assert: node selector equals: #asInteger.
+	self assert: node selector equals: #asInteger
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testOnceBreakpoint [
+SindarinDebuggerTests >> testOnceBreakpoint [
 	| breakpoint scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg step; step.
@@ -380,22 +396,22 @@ ScriptableDebuggerTests >> testOnceBreakpoint [
 	scdbg continue.
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg continue.
-	self assert: scdbg isExecutionFinished.
+	self assert: scdbg isExecutionFinished
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testReceiver [
+SindarinDebuggerTests >> testReceiver [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod8 ].
 	self assert: scdbg receiver equals: self.
 	scdbg step.
 	self assert: scdbg receiver equals: self.
 	scdbg step; step.
-	self assert: scdbg receiver equals: '3'.
+	self assert: scdbg receiver equals: '3'
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testRemoveBreakpoint [
+SindarinDebuggerTests >> testRemoveBreakpoint [
 	| breakpoint scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg step; step.
@@ -405,63 +421,72 @@ ScriptableDebuggerTests >> testRemoveBreakpoint [
 	breakpoint remove.
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg continue.
-	self assert: scdbg isExecutionFinished.
+	self assert: scdbg isExecutionFinished
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testSelector [
+SindarinDebuggerTests >> testSelector [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod9 ].
 	self assert: scdbg selector equals: #testSelector.
 	scdbg step.
 	self assert: scdbg selector equals: #helperMethod9.
 	scdbg step; step.
-	self assert: scdbg selector equals: #asInteger.
+	self assert: scdbg selector equals: #asInteger
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testSetBreakpoint [
-	self testContinue.
+SindarinDebuggerTests >> testSetBreakpoint [
+	self flag: 'What is this test?'.
+	self testContinue
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testSkip [
-	|a p scdbg |
+SindarinDebuggerTests >> testSkip [
+	| a p scdbg |
 	a := 1.
-	scdbg := SindarinDebugger debug: [ a := 2. p := Point x: 2 y: 3].
+	scdbg := SindarinDebugger
+		debug: [ a := 2.
+			p := Point x: 2 y: 3 ].
 	scdbg skip.
 	self assert: a equals: 1.
 	scdbg skip.
 	scdbg step.
-	self assert: p equals: nil.
+	self assert: p equals: nil
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testSkipWith [
-	|a p scdbg |
+SindarinDebuggerTests >> testSkipWith [
+	| a p scdbg |
 	a := 1.
-	scdbg := SindarinDebugger debug: [ a := 2. p := Point x: 2 y: 3].
+	scdbg := SindarinDebugger
+		debug: [ a := 2.
+			p := Point x: 2 y: 3 ].
 	scdbg skipWith: 3.
 	self assert: a equals: 1.
 	scdbg skipWith: 5.
 	scdbg step.
-	self assert: p equals: 5.
+	self assert: p equals: 5
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testStack [
+SindarinDebuggerTests >> testStack [
 	| context1 context2 storeContextBlock scdbg |
 	storeContextBlock := [ :thisCtx | context2 := thisCtx ].
-	scdbg := SindarinDebugger debug: [ context1 := thisContext. self helperMethod17: storeContextBlock ].
+	scdbg := SindarinDebugger
+		debug: [ context1 := thisContext.
+			self helperMethod17: storeContextBlock ].
 	scdbg step.
 	self assert: scdbg stack first equals: context1.
-	scdbg step; stepOver.
+	scdbg
+		step;
+		stepOver.
 	self assert: scdbg stack first equals: context2.
-	self assert: (scdbg stack at: 2) equals: context1.
+	self assert: (scdbg stack at: 2) equals: context1
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testStep [
+SindarinDebuggerTests >> testStep [
 	| node scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod13 ].
 	scdbg step.
@@ -471,19 +496,19 @@ ScriptableDebuggerTests >> testStep [
 	scdbg step.
 	node := scdbg node.
 	self assert: node isMessage.
-	self assert: node selector equals: #asInteger.
+	self assert: node selector equals: #asInteger
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testStepOver [
-	|scdbg|
+SindarinDebuggerTests >> testStepOver [
+	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod14 ].
 	scdbg stepOver.
-	self assert: scdbg node isBlock.
+	self assert: scdbg node isBlock
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testStepOverReturnNode [
+SindarinDebuggerTests >> testStepOverReturnNode [
 	|scdbg|
 	scdbg := SindarinDebugger debug: [ self helperMethod21 ].
 	scdbg step; step.
@@ -491,29 +516,37 @@ ScriptableDebuggerTests >> testStepOverReturnNode [
 	self shouldnt: [scdbg stepOver] raise: SteppingATerminatingProcess.
 	self assert: scdbg selector equals: #helperMethod21.
 	self assert: scdbg node isMethod.
+	self flag: 'Why is the following commented? Should it be tested somehow?'
 "	self assert: scdbg node isBlock."
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testStepUntil [
+SindarinDebuggerTests >> testStepUntil [
 	| i scdbg |
 	i := 20.
-	scdbg := SindarinDebugger debug: [ [i = 0] whileFalse: [i := i - 1]].
+	scdbg := SindarinDebugger
+		debug: [ [ i = 0 ] whileFalse: [ i := i - 1 ] ].
 	scdbg stepUntil: [ i = 12 ].
-	self assert: i equals: 12.
+	self assert: i equals: 12
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testSteppingAnExecutionSignalingExceptions [
+SindarinDebuggerTests >> testSteppingAnExecutionSignalingExceptions [
 	| scdbg |
-	scdbg := SindarinDebugger debug: [ 1/0. 2/0. 3/0. ].
-	self should: [ 
-		scdbg stepOver; stepOver; stepOver.
-	] raise: UnhandledExceptionSignalledByADebuggedExecution.
+	scdbg := SindarinDebugger
+		debug: [ 1 / 0.
+			2 / 0.
+			3 / 0 ].
+	self
+		should: [ scdbg
+				stepOver;
+				stepOver;
+				stepOver ]
+		raise: UnhandledExceptionSignalledByADebuggedExecution
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testTemporaries [
+SindarinDebuggerTests >> testTemporaries [
 	| scdbg |
 	scdbg := SindarinDebugger debug: [ self helperMethod10 ].
 	self assert: scdbg temporaries size equals: 1.
@@ -522,11 +555,11 @@ ScriptableDebuggerTests >> testTemporaries [
 	self assert: (scdbg temporaries at: #a) equals: nil.
 	scdbg step.
 	self assert: scdbg temporaries size equals: 1.
-	self assert: (scdbg temporaries at: #a) equals: 5.
+	self assert: (scdbg temporaries at: #a) equals: 5
 ]
 
 { #category : #tests }
-ScriptableDebuggerTests >> testWhenHitBreakpoint [
+SindarinDebuggerTests >> testWhenHitBreakpoint [
 	| breakpoint toggle scdbg |
 	toggle := false.
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
@@ -537,5 +570,5 @@ ScriptableDebuggerTests >> testWhenHitBreakpoint [
 	breakpoint whenHit: [ toggle := true ].
 	scdbg := SindarinDebugger debug: [ self helperMethod19 ].
 	scdbg continue.
-	self assert: toggle.
+	self assert: toggle
 ]

--- a/Sindarin/DebugSession.extension.st
+++ b/Sindarin/DebugSession.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #DebugSession }
 
 { #category : #'*Sindarin' }
-DebugSession >> isSindarinDebugSession [
-	^ false
+DebugSession >> asSindarinDebugSession [
+	^ SindarinDebugSession new debugSession: self
 ]

--- a/Sindarin/SindarinDebugSession.class.st
+++ b/Sindarin/SindarinDebugSession.class.st
@@ -5,7 +5,7 @@ StepRecords: LinkedList[StepRecord]
 "
 Class {
 	#name : #SindarinDebugSession,
-	#superclass : #DebugSession,
+	#superclass : #Object,
 	#instVars : [
 		'triggerEventOn',
 		'canBeTerminated',
@@ -25,6 +25,7 @@ SindarinDebugSession class >> newWithName: aString forProcess: aProcess [
 { #category : #initialization }
 SindarinDebugSession >> activateEventTriggering [
 	triggerEventOn := true.
+	self flag: 'Why not refreshing?'.
 	"self refreshAttachedDebugger."
 ]
 
@@ -65,16 +66,10 @@ SindarinDebugSession >> initialize [
 	canBeTerminated := true
 ]
 
-{ #category : #testing }
-SindarinDebugSession >> isSindarinDebugSession [
-	^ true
-]
-
 { #category : #initialization }
 SindarinDebugSession >> refreshAttachedDebugger [
-	"The following lines are to force the debugger to update itself based on its debugSession"
-	self triggerEvent: #contextChanged.
-	"self triggerEvent: #stepInto" "Since SpecDebugger's #updateContextChanged eventually calls the same #updateStep method that its #updateStepInto method does, there is no point in causing a double refresh by also triggering the #stepInto event"
+	"The following lines are to force possible debuggers observing the same debug session to update themselves based"
+	self debugSession triggerEvent: #contextChanged
 ]
 
 { #category : #'debugging actions' }
@@ -82,9 +77,9 @@ SindarinDebugSession >> stepInto: aContext [
 	"Should not step more a process that is terminating, otherwise the image will get locked."
 	self flag: 'Why the image gets locked? Please investigate.'.
 
-	self interruptedProcess isTerminating
+	self debugSession interruptedProcess isTerminating
 		ifTrue: [ SteppingATerminatingProcess signal ].
-	^ super stepInto: aContext
+	^ self debugSession stepInto: aContext
 ]
 
 { #category : #'debugging actions' }
@@ -92,23 +87,18 @@ SindarinDebugSession >> stepOver: aContext [
 	"Should not step more a process that is terminating, otherwise the image will get locked."
 	self flag: 'Why the image gets locked? Please investigate.'.
 	
-	self interruptedProcess isTerminating
+	self debugSession interruptedProcess isTerminating
 		ifTrue: [ SteppingATerminatingProcess signal ].
-	^ super stepOver: aContext
+	^ self debugSession stepOver: aContext
 ]
 
 { #category : #'debugging actions' }
 SindarinDebugSession >> terminate [
-	canBeTerminated ifTrue: [ ^ super terminate ].
+	canBeTerminated ifTrue: [ ^ self debugSession terminate ].
 ]
 
 { #category : #'debugging actions' }
 SindarinDebugSession >> triggerEvent: anEventSelector [
 	triggerEventOn
-		ifTrue: [ ^ super triggerEvent: anEventSelector ]
-]
-
-{ #category : #accessing }
-SindarinDebugSession >> triggerEventOn [
-	^ triggerEventOn
+		ifTrue: [ ^ self debugSession triggerEvent: anEventSelector ]
 ]

--- a/Sindarin/SindarinDebugSession.class.st
+++ b/Sindarin/SindarinDebugSession.class.st
@@ -94,7 +94,8 @@ SindarinDebugSession >> stepOver: aContext [
 
 { #category : #'debugging actions' }
 SindarinDebugSession >> terminate [
-	canBeTerminated ifTrue: [ ^ self debugSession terminate ].
+	canBeTerminated
+		ifTrue: [ ^ self debugSession terminate ]
 ]
 
 { #category : #'debugging actions' }

--- a/Sindarin/SindarinDebugSession.class.st
+++ b/Sindarin/SindarinDebugSession.class.st
@@ -8,27 +8,29 @@ Class {
 	#superclass : #DebugSession,
 	#instVars : [
 		'triggerEventOn',
-		'canBeTerminated'
+		'canBeTerminated',
+		'debugSession'
 	],
 	#category : #Sindarin
 }
 
 { #category : #'instance creation' }
-SindarinDebugSession class >> forDebugSession: aDebugSession [
-	"Creates a DebugSessionPlus on the same execution as aDebugSession"
-	^ self newWithName: aDebugSession name forProcess: aDebugSession interruptedProcess.
-	
-]
-
-{ #category : #'instance creation' }
 SindarinDebugSession class >> newWithName: aString forProcess: aProcess [
-	^ self new name: aString; process: aProcess context: aProcess suspendedContext; yourself.
+	^ DebugSession new
+		name: aString;
+		process: aProcess context: aProcess suspendedContext;
+		asSindarinDebugSession
 ]
 
 { #category : #initialization }
 SindarinDebugSession >> activateEventTriggering [
 	triggerEventOn := true.
 	"self refreshAttachedDebugger."
+]
+
+{ #category : #converting }
+SindarinDebugSession >> asSindarinDebugSession [
+	^ self
 ]
 
 { #category : #accessing }
@@ -44,6 +46,16 @@ SindarinDebugSession >> canBeTerminated: anObject [
 { #category : #initialization }
 SindarinDebugSession >> deactivateEventTriggering [
 	triggerEventOn := false.
+]
+
+{ #category : #accessing }
+SindarinDebugSession >> debugSession [
+	^ debugSession
+]
+
+{ #category : #accessing }
+SindarinDebugSession >> debugSession: anObject [
+	debugSession := anObject
 ]
 
 { #category : #initialization }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -78,10 +78,7 @@ SindarinDebugger >> assignmentVariableName [
 SindarinDebugger >> attachTo: aDebugSession [
 	"Attaches this scriptable debugger to an already existing instance of DebugSession or DebugSessionPlus"
 
-	debugSession := aDebugSession.
-	aDebugSession isSindarinDebugSession
-		ifFalse:
-			[ debugSession := SindarinDebugSession forDebugSession: aDebugSession.].
+	debugSession := aDebugSession asSindarinDebugSession.
 	process := debugSession interruptedProcess.
 	debugSession deactivateEventTriggering.
 	^ self

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -19,10 +19,10 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'process',
-		'debugSession',
 		'stepHooks',
 		'nodeMapForMethod',
-		'debugStarted'
+		'debugStarted',
+		'sindarinSession'
 	],
 	#category : #Sindarin
 }
@@ -43,8 +43,7 @@ SindarinDebugger class >> debug: aBlock [
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> activateAutoRefreshOfAttachedGraphicalDebugger [
-	"Does not work for the GT debugger"
-	debugSession activateEventTriggering.
+	sindarinSession activateEventTriggering.
 	self refreshAttachedGraphicalDebugger.
 ]
 
@@ -76,18 +75,19 @@ SindarinDebugger >> assignmentVariableName [
 
 { #category : #start }
 SindarinDebugger >> attachTo: aDebugSession [
-	"Attaches this scriptable debugger to an already existing instance of DebugSession or DebugSessionPlus"
+	"Attaches this scriptable debugger to an already existing instance of DebugSession or SindarinDebugSession"
 
-	debugSession := aDebugSession asSindarinDebugSession.
-	process := debugSession interruptedProcess.
-	debugSession deactivateEventTriggering.
+	sindarinSession := aDebugSession asSindarinDebugSession.
+	process := sindarinSession interruptedProcess.
+	sindarinSession deactivateEventTriggering.
 	^ self
 ]
 
 { #category : #stackAccess }
 SindarinDebugger >> context [
 	"Returns a reification of the current stack-frame."
-	^ debugSession interruptedContext.
+
+	^ self debugSession interruptedContext
 ]
 
 { #category : #private }
@@ -152,26 +152,28 @@ SindarinDebugger >> currentContextStackSize [
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> deactivateAutoRefreshOfAttachedGraphicalDebugger [
-	"Does not work for the GT debugger"
-	debugSession deactivateEventTriggering.
+	sindarinSession deactivateEventTriggering
 ]
 
 { #category : #start }
 SindarinDebugger >> debug: aBlock [
-	process := aBlock newProcess name: 'ExecutionDebuggedByScriptableDebugger'.
+	process := aBlock newProcess
+		name: 'ExecutionDebuggedByScriptableDebugger'.
 	"process on: Exception do: [:ex | DebuggedExecutionSignalledAnException signalWithException: ex. ex resume ]."
-	debugSession := SindarinDebugSession newWithName: 'ScriptableDebuggerDebugSession' forProcess: process.
-		debugSession deactivateEventTriggering.
-	[ self selector = #newProcess] whileFalse: [ self step]. "Step the process to get out of the on:do: context added at the bottom of its stack"
-	[self selector = #newProcess] whileTrue: [ self step ]. "Step the process so that it leaves BlockClosure>>#newProcess and enters the block for which a process was created"
-	debugStarted := true.
-	^ self
+	sindarinSession := SindarinDebugSession
+		newWithName: 'ScriptableDebuggerDebugSession'
+		forProcess: process.
+	sindarinSession deactivateEventTriggering.
+	[ self selector = #newProcess ] whileFalse: [ self step ].	"Step the process to get out of the on:do: context added at the bottom of its stack"
+	[ self selector = #newProcess ] whileTrue: [ self step ].	"Step the process so that it leaves BlockClosure>>#newProcess and enters the block for which a process was created"
+	debugStarted := true
 ]
 
 { #category : #accessing }
 SindarinDebugger >> debugSession [
 	"Returns the DebugSession representing the execution this ScriptableDebugger is debugging"
-	^ debugSession 
+
+	^ sindarinSession debugSession
 ]
 
 { #category : #initialization }
@@ -276,8 +278,8 @@ SindarinDebugger >> nodeMapForMethod: aCompiledMethod [
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> openInGraphicalDebugger [
-	debugSession canBeTerminated: false. "Prevents the graphical debugger from terminating the debug session when it's closed."
-	GTGenericStackDebugger openOn: debugSession withFullView: true.
+	sindarinSession canBeTerminated: false. "Prevents the graphical debugger from terminating the debug session when it's closed."
+	GTGenericStackDebugger openOn: sindarinSession withFullView: true.
 ]
 
 { #category : #stepping }
@@ -294,8 +296,7 @@ SindarinDebugger >> receiver [
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> refreshAttachedGraphicalDebugger [
-	"Does not work for the GT debugger"
-	debugSession refreshAttachedDebugger.
+	sindarinSession refreshAttachedDebugger.
 ]
 
 { #category : #'step hook' }
@@ -387,15 +388,16 @@ SindarinDebugger >> skipWith: replacementValue [
 { #category : #stackAccess }
 SindarinDebugger >> stack [
 	"Returns a list of context objects representing the current call stack."
-	^ debugSession stack
+	^ self debugSession stack
 ]
 
 { #category : #stepping }
 SindarinDebugger >> step [
 	"Executes the next instruction. If the instruction is a message-send, step inside it."
+
 	self signalExceptionIfDebuggedExecutionHasSignalledException.
-	debugSession stepInto.
-	stepHooks do: [ :aBlock | aBlock value ].
+	self debugSession stepInto.
+	stepHooks do: [ :aBlock | aBlock value ]
 ]
 
 { #category : #stepping }
@@ -421,9 +423,10 @@ SindarinDebugger >> stepOver: anInt [
 { #category : #stepping }
 SindarinDebugger >> stepThrough [
 	"Hacked for demonstration purposes to have a stepThrough"
+
 	self signalExceptionIfDebuggedExecutionHasSignalledException.
-	debugSession stepThrough.
-	stepHooks do: [ :aBlock | aBlock value ].
+	self debugSession stepThrough.
+	stepHooks do: [ :aBlock | aBlock value ]
 ]
 
 { #category : #stepping }

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -44,33 +44,39 @@ SindarinDebugger class >> debug: aBlock [
 { #category : #'graphical debugger' }
 SindarinDebugger >> activateAutoRefreshOfAttachedGraphicalDebugger [
 	sindarinSession activateEventTriggering.
-	self refreshAttachedGraphicalDebugger.
+	self refreshAttachedGraphicalDebugger
 ]
 
 { #category : #'step hook' }
 SindarinDebugger >> addStepHook: aBlock [
 	"Adds aBlock to the list of step hooks. Step hooks are executed after each step of the execution"
+
 	stepHooks add: aBlock
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> arguments [
 	"Returns the arguments of the current stack-frame."
+
 	^ self context arguments
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> assignmentValue [
 	"Returns the value about to be assigned, if the current node is an assignment node. Otherwise, returns nil"
-	(self node isAssignment) ifFalse: [ ^ nil. "Error signal: 'Not about to perform a assignment'" ].
-	^ self context at: self currentContextStackSize.
+
+	self node isAssignment
+		ifFalse: [ ^ nil	"Error signal: 'Not about to perform a assignment'" ].
+	^ self context at: self currentContextStackSize
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> assignmentVariableName [
 	"Returns the variable name about to be assigned to, if the current node is an assignment node. Otherwise, returns nil"
-	(self node isAssignment) ifFalse: [ ^ nil. "Error signal: 'Not about to perform a assignment'" ].
-	^ self node variable name.
+
+	self node isAssignment
+		ifFalse: [ ^ nil	"Error signal: 'Not about to perform a assignment'" ].
+	^ self node variable name
 ]
 
 { #category : #start }
@@ -79,8 +85,7 @@ SindarinDebugger >> attachTo: aDebugSession [
 
 	sindarinSession := aDebugSession asSindarinDebugSession.
 	process := aDebugSession interruptedProcess.
-	sindarinSession deactivateEventTriggering.
-	^ self
+	sindarinSession deactivateEventTriggering
 ]
 
 { #category : #stackAccess }
@@ -119,6 +124,7 @@ SindarinDebugger >> continue [
 	- has finished. In this case return nil."
 
 	| signalMessageNode exceptionClassBeingSignalled stepHook |
+	self flag: 'Sorry, this is shit :)'.
 	stepHook := [ VirtualBreakpoint all
 		detect: [ :vbrkpt | vbrkpt hitTest: self node ]
 		ifFound: [ :vbrkpt | 
@@ -147,7 +153,7 @@ SindarinDebugger >> continue [
 
 { #category : #private }
 SindarinDebugger >> currentContextStackSize [
-	^ self context basicSize.
+	^ self context basicSize
 ]
 
 { #category : #'graphical debugger' }
@@ -159,6 +165,7 @@ SindarinDebugger >> deactivateAutoRefreshOfAttachedGraphicalDebugger [
 SindarinDebugger >> debug: aBlock [
 	process := aBlock newProcess
 		name: 'ExecutionDebuggedByScriptableDebugger'.
+
 	"process on: Exception do: [:ex | DebuggedExecutionSignalledAnException signalWithException: ex. ex resume ]."
 	sindarinSession := SindarinDebugSession
 		newWithName: 'ScriptableDebuggerDebugSession'
@@ -185,65 +192,82 @@ SindarinDebugger >> initialize [
 { #category : #stackAccess }
 SindarinDebugger >> isExecutionFinished [
 	"Returns whether the debugged execution is finished"
+
 	^ process isTerminating
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> message: aSelector to: anObject [
 	"Returns whether the execution is about to send a message of selector @aSelector to @anObject"
+
 	| node |
 	node := self node.
-	node isMessage ifFalse: [ ^ false ].
-	node selector = aSelector ifFalse: [ ^ false ].
-	(self messageReceiver == anObject) ifFalse: [ ^ false ].
+	node isMessage
+		ifFalse: [ ^ false ].
+	node selector = aSelector
+		ifFalse: [ ^ false ].
+	self messageReceiver == anObject
+		ifFalse: [ ^ false ].
 	^ true
-
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> message: aSelector toInstanceOf: aClass [
 	"Returns whether the execution is about to send a message of selector @aSelector to an instance of class @aClass"
+
 	| node |
 	node := self node.
-	node isMessage ifFalse: [ ^ false ].
-	node selector = aSelector ifFalse: [ ^ false ].
-	(self messageReceiver isKindOf:  aClass) ifFalse: [ ^ false ].
+	node isMessage
+		ifFalse: [ ^ false ].
+	node selector = aSelector
+		ifFalse: [ ^ false ].
+	(self messageReceiver isKindOf: aClass)
+		ifFalse: [ ^ false ].
 	^ true
-
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> messageArguments [
 	"Returns the arguments of the message about to be sent, if the current node is a message node."
+
 	| argumentNumber arguments i |
-	(self node isMessage) ifFalse: [ Error signal: 'Not about to send a message' ].
+	self node isMessage
+		ifFalse: [ Error signal: 'Not about to send a message' ].
 	argumentNumber := self node arguments size.
 	arguments := OrderedCollection new.
 	i := 0.
-	[i = argumentNumber] whileFalse: [ 
-		arguments add: (self context at: self currentContextStackSize - argumentNumber + i + 1).
-		i := i + 1.
-	].
-	^ arguments.
+	[ i = argumentNumber ]
+		whileFalse: [ arguments
+				add:
+					(self context
+						at: self currentContextStackSize - argumentNumber + i + 1).
+			i := i + 1 ].
+	^ arguments
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> messageReceiver [
 	"Returns the receiver of the message about to be sent, if the current node is a message node."
-	(self node isMessage) ifFalse: [ Error signal: 'Not about to send a message' ].
-	^ self context at: (self currentContextStackSize) - (self node arguments size).
+
+	self node isMessage
+		ifFalse: [ Error signal: 'Not about to send a message' ].
+	^ self context
+		at: self currentContextStackSize - self node arguments size
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> messageSelector [
 	"Returns the selector of the message about to be sent, if the current node is a message node."
-	(self node isMessage) ifFalse: [ Error signal: 'Not about to send a message' ].
-	^ self node selector.
+
+	self node isMessage
+		ifFalse: [ Error signal: 'Not about to send a message' ].
+	^ self node selector
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> method [
 	"Returns the method of the current stack-frame."
+
 	^ self context method
 ]
 
@@ -251,96 +275,110 @@ SindarinDebugger >> method [
 SindarinDebugger >> node [
 	"Returns the AST node about to be executed by the top context of the execution"
 
-	debugStarted ifFalse: [ 
-		"Until the debug session is started, node is returned using the unoptimized version"
-		"Sindarin starts by executing controlled steps to exit the caller code (e.g. tests)
+	debugStarted
+		ifFalse:
+			[ "Until the debug session is started, node is returned using the unoptimized version" "Sindarin starts by executing controlled steps to exit the caller code (e.g. tests)
 		before entering the actual debugged code, and we do not want to cache nodes for the 
-		caller code."
-		^ self context method sourceNodeForPC: self context pc ].
+		caller code." ^ self context method sourceNodeForPC: self context pc ].
 	"Once the hand is given to the tool or user, we start caching nodes for better performance"
 	^ self nodeMap nodeForPC: self context pc
 ]
 
 { #category : #astAndAstMapping }
 SindarinDebugger >> nodeMap [
-	^self nodeMapForMethod: self context method 
+	^ self nodeMapForMethod: self context method
 ]
 
 { #category : #astAndAstMapping }
 SindarinDebugger >> nodeMapForMethod: aCompiledMethod [
 	nodeMapForMethod ifNil: [ nodeMapForMethod := Dictionary new ].
 	^ (nodeMapForMethod
-		   at: aCompiledMethod methodClass name
-		   ifAbsentPut: [ Dictionary new ])
-		  at: aCompiledMethod selector
-		  ifAbsentPut: [ SindarinBytecodeToASTCache generateForCompiledMethod: aCompiledMethod ]
+		at: aCompiledMethod methodClass name
+		ifAbsentPut: [ Dictionary new ])
+		at: aCompiledMethod selector
+		ifAbsentPut: [ SindarinBytecodeToASTCache
+				generateForCompiledMethod: aCompiledMethod ]
 ]
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> openInGraphicalDebugger [
-	sindarinSession canBeTerminated: false. "Prevents the graphical debugger from terminating the debug session when it's closed."
-	GTGenericStackDebugger openOn: sindarinSession withFullView: true.
+	sindarinSession canBeTerminated: false.	"Prevents the graphical debugger from terminating the debug session when it's closed."
+	self
+		flag:
+			'Should be an extension of DebuggerSelector and handled by its sole instance'
 ]
 
 { #category : #stepping }
 SindarinDebugger >> proceed [
 	"alias of #continue"
+
 	^ self continue
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> receiver [
 	"Returns the receiver of the current stack-frame."
+
 	^ self context receiver
 ]
 
 { #category : #'graphical debugger' }
 SindarinDebugger >> refreshAttachedGraphicalDebugger [
-	sindarinSession refreshAttachedDebugger.
+	sindarinSession refreshAttachedDebugger
 ]
 
 { #category : #'step hook' }
 SindarinDebugger >> removeStepHook: aBlock [
 	"Remove aBlock from the list of step hooks"
+
 	stepHooks remove: aBlock
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> selector [
 	"Returns the selector of the current stack-frame."
+
 	^ self context selector
 ]
 
 { #category : #breakpoints }
 SindarinDebugger >> setBreakpoint [
 	"Sets a breakpoint on the current node, returns an object reifying the breakpoint."
-	^ self setBreakpointOn: self node.
+
+	^ self setBreakpointOn: self node
 ]
 
 { #category : #breakpoints }
 SindarinDebugger >> setBreakpointOn: target [
 	"Sets a breakpoint on target (a node or a compiled method), returns an object reifying the breakpoint."
-	| astTarget|
+
+	| astTarget |
 	astTarget := target.
-	(target isKindOf: CompiledMethod) ifTrue: [ astTarget := target ast ].
-	^ VirtualBreakpoint newOnNode: astTarget setBy: self.
+	(target isKindOf: CompiledMethod)
+		ifTrue: [ astTarget := target ast ].
+	^ VirtualBreakpoint newOnNode: astTarget setBy: self
 ]
 
 { #category : #private }
 SindarinDebugger >> signalExceptionIfDebuggedExecutionHasSignalledException [
 	| unhandledException |
-	((self node isMessage) and: [(self messageSelector = #unhandledErrorDefaultAction:) and: [ self messageReceiver isKindOf: UIManager ]]) ifTrue: [ 
-	"The debugged execution signalled an exception, this exception was not handled and is about to cause a debugger to open."
-	"Signalling an exception **in the scriptable debugger's process** to inform the user of this"
-		unhandledException := self messageArguments at: 1.
-		UnhandledExceptionSignalledByADebuggedExecution signalWithException: unhandledException.
-	].
+	self flag: 'Could we not simplify this?'.
+	(self node isMessage
+		and: [ self messageSelector = #unhandledErrorDefaultAction:
+				and: [ self messageReceiver isKindOf: UIManager ] ])
+		ifTrue:
+			[ "The debugged execution signalled an exception, this exception was not handled and is about to cause a debugger to open."
+			"Signalling an exception **in the scriptable debugger's process** to inform the user of this"
+			unhandledException := self messageArguments at: 1.
+			UnhandledExceptionSignalledByADebuggedExecution
+				signalWithException: unhandledException ]
 ]
 
 { #category : #stepping }
 SindarinDebugger >> skip [
 	"If it is a message send or assignment, skips the execution of the current instruction, and puts nil on the execution stack."
-	self skipWith: nil.
+
+	self skipWith: nil
 ]
 
 { #category : #private }
@@ -388,6 +426,7 @@ SindarinDebugger >> skipWith: replacementValue [
 { #category : #stackAccess }
 SindarinDebugger >> stack [
 	"Returns a list of context objects representing the current call stack."
+
 	^ self debugSession stack
 ]
 
@@ -403,20 +442,25 @@ SindarinDebugger >> step [
 { #category : #stepping }
 SindarinDebugger >> step: anInt [
 	"Call the #step method @anInt times"
-	anInt timesRepeat: [ self step ].
+
+	anInt timesRepeat: [ self step ]
 ]
 
 { #category : #stepping }
 SindarinDebugger >> stepOver [
-	|startContext|
+	| startContext |
 	startContext := self context.
 	self step.
-	[ (self context == startContext) or: [ (startContext sender isNil) or: [startContext hasSender: self context] ] ] whileFalse: [ self step.].
+	[ self context == startContext
+		or: [ startContext sender isNil
+				or: [ startContext hasSender: self context ] ] ]
+		whileFalse: [ self step ]
 ]
 
 { #category : #stepping }
 SindarinDebugger >> stepOver: anInt [
 	"Call the #stepOver method @anInt times"
+
 	anInt timesRepeat: [ self stepOver ]
 ]
 
@@ -432,11 +476,13 @@ SindarinDebugger >> stepThrough [
 { #category : #stepping }
 SindarinDebugger >> stepUntil: aBlock [
 	"Steps the execution until aBlock evaluates to true"
+
 	aBlock whileFalse: [ self step ]
 ]
 
 { #category : #stackAccessHelpers }
 SindarinDebugger >> temporaries [
 	"Returns the temporary variables of the current stack-frame."
-	^ self context temporaries.
+
+	^ self context temporaries
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -78,7 +78,7 @@ SindarinDebugger >> attachTo: aDebugSession [
 	"Attaches this scriptable debugger to an already existing instance of DebugSession or SindarinDebugSession"
 
 	sindarinSession := aDebugSession asSindarinDebugSession.
-	process := sindarinSession interruptedProcess.
+	process := aDebugSession interruptedProcess.
 	sindarinSession deactivateEventTriggering.
 	^ self
 ]


### PR DESCRIPTION
Now `SindarinDebugSession` is not a subclass of `DebugSession` anymore, but delegates to an instance of `DebugSession`  instead.
Also did a pass over tests.