### PR TITLE
Fixing tests and features by using `InstructionStream` instead of `Context`

### DIFF
--- a/Sindarin-Tests/SindarinDebuggerTest.class.st
+++ b/Sindarin-Tests/SindarinDebuggerTest.class.st
@@ -804,7 +804,7 @@ SindarinDebuggerTest >> testStepToReturnWithHalt [
 	dbg stepToMethodEntry.
 	dbg stepToReturn.
 	
-	self assert: dbg context willReturn.
+	self assert: dbg context instructionStream willReturn.
 	self assert: dbg node isReturn.
 	self assert: dbg topStack equals: 1
 ]

--- a/Sindarin/SindarinDebugger.class.st
+++ b/Sindarin/SindarinDebugger.class.st
@@ -645,7 +645,7 @@ SindarinDebugger >> stepThrough [
 
 { #category : #'stepping - steps' }
 SindarinDebugger >> stepToMethodEntry [
-	self stepUntil: [ self context willSend ].
+	self stepUntil: [ self context instructionStream willSend ].
 	process step: self context.
 	self debugSession updateContextTo: process suspendedContext
 ]
@@ -654,7 +654,7 @@ SindarinDebugger >> stepToMethodEntry [
 SindarinDebugger >> stepToReturn [
 
 	[ 
-	self context willReturn or: [ self hasSignalledUnhandledException ] ] 
+	self context instructionStream willReturn or: [ self hasSignalledUnhandledException ] ] 
 		whileFalse: [ self debugSession stepOver ]
 ]
 


### PR DESCRIPTION
Fix #17 
Sindarin methods that were using methods that have been migrated from `Context` to `InstructionStream` are now called on the instruction stream of the context instead of the context itself